### PR TITLE
Apply monochrome glass styling across pages

### DIFF
--- a/public/about.css
+++ b/public/about.css
@@ -53,5 +53,5 @@
 .social-links a:hover {
     border-color: var(--primary-glow);
     color: var(--primary-glow);
-    box-shadow: 0 0 20px rgba(0, 212, 255, 0.3);
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
 }

--- a/public/admin.css
+++ b/public/admin.css
@@ -1,20 +1,20 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 :root {
-    --admin-primary: #ff3b3b;
-    --admin-primary-light: #ffa63b;
-    --admin-primary-dark: #8b0000;
-    --admin-accent: #ff8c00;
+    --admin-primary: #ffffff;
+    --admin-primary-light: #e5e5e5;
+    --admin-primary-dark: #888888;
+    --admin-accent: #cccccc;
     --admin-bg: #000000;
-    --admin-surface: #1a0000;
-    --admin-surface-light: #2a0a00;
+    --admin-surface: #1a1a1a;
+    --admin-surface-light: #2a2a2a;
     --admin-border: rgba(255, 255, 255, 0.1);
-    --admin-text: #f1f5f9;
-    --admin-text-secondary: #94a3b8;
-    --admin-text-muted: #64748b;
-    --admin-success: #10b981;
-    --admin-danger: #ef4444;
-    --admin-warning: #f59e0b;
+    --admin-text: #f5f5f5;
+    --admin-text-secondary: #a0a0a0;
+    --admin-text-muted: #777777;
+    --admin-success: #777777;
+    --admin-danger: #555555;
+    --admin-warning: #999999;
     --sidebar-width: 260px;
 }
 
@@ -51,9 +51,12 @@ body.sidebar-open {
     left: 0;
     right: 0;
     bottom: 0;
-    background: transparent;
-    opacity: 0;
+    background:
+        radial-gradient(circle at 50% 0, rgba(255, 255, 255, 0.1), transparent 70%),
+        radial-gradient(circle at 80% 100%, rgba(255, 255, 255, 0.05), transparent 70%);
     pointer-events: none;
+    filter: blur(120px);
+    z-index: -1;
 }
 
 /* Access Overlays */
@@ -79,6 +82,7 @@ body.sidebar-open {
     max-width: 480px;
     width: 90%;
     backdrop-filter: blur(20px);
+    border: 1px solid var(--admin-border);
 }
 
 .access-content h2 {
@@ -125,7 +129,7 @@ body.sidebar-open {
 
 .btn-back:hover {
     transform: translateY(-2px);
-    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.3);
+    box-shadow: 0 12px 24px rgba(255, 255, 255, 0.2);
 }
 
 /* Sidebar */
@@ -337,11 +341,14 @@ body.sidebar-open {
 }
 
 .stat-card {
-    background: var(--admin-surface);
+    background: var(--glass-bg);
+    border: 1px solid var(--admin-border);
     border-radius: 16px;
     padding: 24px;
     position: relative;
     overflow: hidden;
+    backdrop-filter: blur(var(--blur-amount));
+    -webkit-backdrop-filter: blur(var(--blur-amount));
     transition: all 0.3s ease;
 }
 
@@ -357,7 +364,7 @@ body.sidebar-open {
 
 .stat-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 12px 24px rgba(255, 255, 255, 0.1);
 }
 
 .stat-card h3 {
@@ -530,7 +537,7 @@ body.sidebar-open {
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 16px rgba(99, 102, 241, 0.3);
+    box-shadow: 0 8px 16px rgba(255, 255, 255, 0.2);
 }
 
 .btn-secondary {
@@ -569,7 +576,8 @@ body.sidebar-open {
 }
 
 .modal-content {
-    background: var(--admin-surface);
+    background: var(--glass-bg);
+    border: 1px solid var(--admin-border);
     border-radius: 20px;
     padding: 32px;
     max-width: 600px;
@@ -579,6 +587,8 @@ body.sidebar-open {
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
     transform: translateY(20px);
     opacity: 0;
+    backdrop-filter: blur(var(--blur-amount));
+    -webkit-backdrop-filter: blur(var(--blur-amount));
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
 }
 
@@ -647,7 +657,7 @@ body.sidebar-open {
 .form-group select:focus {
     outline: none;
     border-color: var(--admin-primary);
-    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.1);
 }
 
 .form-group textarea {

--- a/public/globals.css
+++ b/public/globals.css
@@ -6,8 +6,13 @@
     --scrollbar-track: rgba(255, 255, 255, 0.05);
     --scrollbar-thumb: rgba(255, 255, 255, 0.1);
     --scrollbar-thumb-hover: rgba(255, 255, 255, 0.2);
-    --selection-bg: rgba(0, 212, 255, 0.3);
-    --selection-color: white;
+    --selection-bg: rgba(255, 255, 255, 0.2);
+    --selection-color: #000;
+    --glass-bg: rgba(255, 255, 255, 0.04);
+    --glass-bg-hover: rgba(255, 255, 255, 0.08);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --hover-bg: rgba(255, 255, 255, 0.12);
+    --blur-amount: 20px;
 }
 
 /* CSS Reset */
@@ -51,7 +56,7 @@ html {
 }
 
 :focus-visible {
-    outline: 2px solid #00d4ff;
+    outline: 2px solid #ffffff;
     outline-offset: 2px;
 }
 
@@ -63,14 +68,47 @@ html {
     padding: 20px;
     margin-top: 40px;
     font-size: 14px;
-    color: var(--text-secondary, #94a3b8);
+    color: var(--text-secondary, #a0a0a0);
 }
 
 .site-footer a {
-    color: var(--text-primary, #f1f5f9);
+    color: var(--text-primary, #f5f5f5);
     text-decoration: none;
 }
 
 .site-footer a:hover {
-    color: var(--primary-glow, #00d4ff);
+    color: var(--primary-glow, #ffffff);
+}
+
+/* Glass utility */
+.glass {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(var(--blur-amount));
+    -webkit-backdrop-filter: blur(var(--blur-amount));
+}
+
+/* Background gradient shapes */
+body::before,
+body::after {
+    content: '';
+    position: fixed;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.1), transparent 70%);
+    z-index: -1;
+    filter: blur(100px);
+    pointer-events: none;
+}
+
+body::before {
+    top: -200px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+body::after {
+    bottom: -200px;
+    right: 50%;
+    transform: translateX(50%);
 }

--- a/public/script.js
+++ b/public/script.js
@@ -218,7 +218,7 @@ function setupSearch() {
                 }
             } catch (error) {
                 console.error('Search error:', error);
-                searchResults.innerHTML = '<p style="color: #f44; text-align: center;">Search error occurred</p>';
+                searchResults.innerHTML = '<p style="color: #666; text-align: center;">Search error occurred</p>';
             }
         }, 300);
     });
@@ -509,9 +509,9 @@ function showNotification(message, type = 'info') {
         top: 100px;
         right: 20px;
         padding: 15px 25px;
-        background: ${type === 'success' ? 'linear-gradient(135deg, #00ff88 0%, #00d4ff 100%)' : 
-                      type === 'error' ? 'linear-gradient(135deg, #ff4444 0%, #ff6666 100%)' : 
-                      'linear-gradient(135deg, #00d4ff 0%, #667eea 100%)'};
+        background: ${type === 'success' ? 'linear-gradient(135deg, #ffffff 0%, #bbbbbb 100%)' :
+                      type === 'error' ? 'linear-gradient(135deg, #888888 0%, #555555 100%)' :
+                      'linear-gradient(135deg, #ffffff 0%, #777777 100%)'};
         color: white;
         border-radius: 10px;
         font-weight: 600;

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,7 @@
 /* Variables */
 :root {
-    --primary-glow: #00d4ff;
-    --secondary-glow: #ff00ff;
+    --primary-glow: #ffffff;
+    --secondary-glow: #777777;
     --glass-bg: rgba(255, 255, 255, 0.04);
     --glass-bg-hover: rgba(255, 255, 255, 0.08);
     --hover-bg: rgba(255, 255, 255, 0.12);
@@ -29,14 +29,27 @@
 }
 
 .mainframe::before {
-    content: "";
+    content: '';
     position: absolute;
     top: -200px;
     left: 50%;
     transform: translateX(-50%);
     width: 1000px;
     height: 400px;
-    background: radial-gradient(circle at 50% 0, rgba(0, 212, 255, 0.4), transparent 70%);
+    background: radial-gradient(circle at 50% 0, rgba(255, 255, 255, 0.15), transparent 70%);
+    pointer-events: none;
+    filter: blur(60px);
+}
+
+.mainframe::after {
+    content: '';
+    position: absolute;
+    bottom: -200px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1000px;
+    height: 400px;
+    background: radial-gradient(circle at 50% 100%, rgba(255, 255, 255, 0.08), transparent 70%);
     pointer-events: none;
     filter: blur(60px);
 }
@@ -99,7 +112,7 @@
 .menu-button:hover {
     background: var(--hover-bg);
     border-color: var(--primary-glow);
-    box-shadow: 0 0 20px rgba(0, 212, 255, 0.3);
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
 }
 
 .menu-icon {
@@ -257,16 +270,16 @@
 
 @keyframes glow {
     from {
-        text-shadow: 
-            0 0 20px rgba(0, 212, 255, 0.5),
-            0 0 40px rgba(0, 212, 255, 0.3),
-            0 0 60px rgba(0, 212, 255, 0.2);
+        text-shadow:
+            0 0 20px rgba(255, 255, 255, 0.4),
+            0 0 40px rgba(255, 255, 255, 0.2),
+            0 0 60px rgba(255, 255, 255, 0.1);
     }
     to {
-        text-shadow: 
-            0 0 30px rgba(255, 0, 255, 0.5),
-            0 0 50px rgba(255, 0, 255, 0.3),
-            0 0 70px rgba(255, 0, 255, 0.2);
+        text-shadow:
+            0 0 30px rgba(170, 170, 170, 0.4),
+            0 0 50px rgba(170, 170, 170, 0.2),
+            0 0 70px rgba(170, 170, 170, 0.1);
     }
 }
 
@@ -327,7 +340,7 @@
     outline: none;
     border-color: var(--primary-glow);
     background: var(--glass-bg-hover);
-    box-shadow: 0 0 30px rgba(0, 212, 255, 0.3);
+    box-shadow: 0 0 30px rgba(255, 255, 255, 0.2);
 }
 
 .search-input::placeholder {
@@ -368,6 +381,11 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 50px;
+    padding: 20px;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    backdrop-filter: blur(var(--blur-amount));
 }
 
 .section-title {
@@ -393,9 +411,9 @@
 }
 
 .new-post-btn:hover {
-    background: rgba(0, 212, 255, 0.1);
+    background: var(--glass-bg-hover);
     border-color: var(--primary-glow);
-    box-shadow: 0 0 20px rgba(0, 212, 255, 0.3);
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
 }
 
 /* Modern Blog Cards */
@@ -430,8 +448,8 @@
 
 .project-card:hover {
     transform: translateY(-8px);
-    border-color: rgba(0, 212, 255, 0.5);
-    box-shadow: 0 20px 40px rgba(0, 212, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.5);
+    box-shadow: 0 20px 40px rgba(255, 255, 255, 0.15);
 }
 
 .project-image {
@@ -524,10 +542,10 @@
 
 .blog-post:hover {
     transform: translateY(-8px) scale(1.02);
-    box-shadow: 
-        0 20px 40px rgba(0, 212, 255, 0.15),
-        0 0 60px rgba(255, 0, 255, 0.1);
-    border-color: rgba(0, 212, 255, 0.5);
+    box-shadow:
+        0 20px 40px rgba(255, 255, 255, 0.15),
+        0 0 60px rgba(200, 200, 200, 0.1);
+    border-color: rgba(255, 255, 255, 0.5);
 }
 
 .post-card-header {
@@ -552,8 +570,8 @@
 
 .post-category {
     padding: 4px 10px;
-    background: rgba(0, 212, 255, 0.1);
-    border: 1px solid rgba(0, 212, 255, 0.3);
+    background: var(--glass-bg-hover);
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 20px;
     font-size: 11px;
     color: var(--primary-glow);
@@ -602,8 +620,8 @@
 }
 
 .post-tag:hover {
-    background: rgba(0, 212, 255, 0.1);
-    border-color: rgba(0, 212, 255, 0.3);
+    background: var(--glass-bg-hover);
+    border-color: var(--primary-glow);
     color: var(--primary-glow);
 }
 
@@ -720,7 +738,7 @@
 }
 
 .post-modal-body::-webkit-scrollbar-thumb {
-    background: rgba(0, 212, 255, 0.3);
+    background: rgba(255, 255, 255, 0.3);
     border-radius: 4px;
 }
 
@@ -764,7 +782,7 @@
 .modal-tag {
     padding: 8px 16px;
     background: var(--glass-bg);
-    border: 1px solid rgba(0, 212, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 30px;
     backdrop-filter: blur(var(--blur-amount));
     font-size: 14px;
@@ -878,7 +896,7 @@
 .form-group textarea:focus {
     outline: none;
     border-color: var(--primary-glow);
-    box-shadow: 0 0 20px rgba(0, 212, 255, 0.2);
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
 }
 
 .form-actions {
@@ -907,7 +925,7 @@
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(0, 212, 255, 0.4);
+    box-shadow: 0 10px 30px rgba(255, 255, 255, 0.3);
 }
 
 .btn-secondary {


### PR DESCRIPTION
## Summary
- apply black-white-dark grey color scheme via shared theme variables
- add glass morphism utility and gradient background shapes
- revamp main and admin pages with glass frames and neutral gradients

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e3ef134832eb48147fa7bf39d1f