### PR TITLE
Fix duplicate Bluesky widget variables

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -103,26 +103,22 @@ async function loadProjects() {
 }
 
 async function loadBlueskyWidget() {
-    if (!bskyEmbed) return;
-    try {
-
-        const response = await fetch(`https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${BSKY_HANDLE}&limit=1`);
-
-        const response = await fetch('https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=vialtyfake&limit=1');
-
-        const data = await response.json();
-        const post = data.feed && data.feed[0]?.post;
-        if (!post) return;
-        const postId = post.uri.split('/').pop();
-
-        const url = encodeURIComponent(`https://bsky.app/profile/${BSKY_HANDLE}/post/${postId}`);
-
-        const url = encodeURIComponent(`https://bsky.app/profile/vialtyfake/post/${postId}`);
-
-        bskyEmbed.src = `https://embed.bsky.app/embed?url=${url}&theme=dark`;
-    } catch (error) {
-        console.error('Error loading Bluesky post:', error);
-    }
+  if (!bskyEmbed) return;
+  try {
+    const response = await fetch(
+      `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${BSKY_HANDLE}&limit=1`
+    );
+    const data = await response.json();
+    const post = data.feed && data.feed[0]?.post;
+    if (!post) return;
+    const postId = post.uri.split('/').pop();
+    const url = encodeURIComponent(
+      `https://bsky.app/profile/${BSKY_HANDLE}/post/${postId}`
+    );
+    bskyEmbed.src = `https://embed.bsky.app/embed?url=${url}&theme=dark`;
+  } catch (error) {
+    console.error('Error loading Bluesky post:', error);
+  }
 }
 
 function renderProjects() {


### PR DESCRIPTION
## Summary
- remove leftover duplicate `response` and `url` variables in Bluesky embed loader

## Testing
- `npm install` *(fails: ENOTEMPTY directory rename)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aade996578832e84842c06e61f970a