### PR TITLE
Replace Bluesky widget with bsky-embed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,8 @@
             </header>
 
             <aside class="bsky-widget" id="bskyWidget">
-                <iframe id="bskyEmbed" title="Latest Bluesky post" loading="lazy"></iframe>
+                <script async src="https://cdn.jsdelivr.net/npm/bsky-embed/dist/bsky-embed.es.js" type="module"></script>
+                <bsky-embed username="vialty.site" limit="1"></bsky-embed>
             </aside>
 
             <!-- Hero Section -->

--- a/public/script.js
+++ b/public/script.js
@@ -10,7 +10,6 @@ const cancelPost = document.getElementById('cancelPost');
 const postForm = document.getElementById('postForm');
 const blogGrid = document.getElementById('blogGrid');
 const projectsGrid = document.getElementById('projectsGrid');
-const bskyEmbed = document.getElementById('bskyEmbed');
 
 // State
 let blogPosts = [];
@@ -19,7 +18,6 @@ window.posts = []; // Global for search
 let projects = [];
 
 const BLOB_BASE_URL = 'https://vialty-blog-images.vercel-blob.com';
-const BSKY_HANDLE = 'vialty.site';
 
 function resolveImageUrl(image) {
     if (!image) return '';
@@ -32,7 +30,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     await checkAdminStatus();
     await loadBlogPosts();
     await loadProjects();
-    await loadBlueskyWidget();
     setupEventListeners();
     setupSearch();
 });
@@ -100,25 +97,6 @@ async function loadProjects() {
             </div>
         `;
     }
-}
-
-async function loadBlueskyWidget() {
-  if (!bskyEmbed) return;
-  try {
-    const response = await fetch(
-      `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${BSKY_HANDLE}&limit=1`
-    );
-    const data = await response.json();
-    const post = data.feed && data.feed[0]?.post;
-    if (!post) return;
-    const postId = post.uri.split('/').pop();
-    const url = encodeURIComponent(
-      `https://bsky.app/profile/${BSKY_HANDLE}/post/${postId}`
-    );
-    bskyEmbed.src = `https://embed.bsky.app/embed?url=${url}&theme=dark`;
-  } catch (error) {
-    console.error('Error loading Bluesky post:', error);
-  }
 }
 
 function renderProjects() {

--- a/public/style.css
+++ b/public/style.css
@@ -953,7 +953,8 @@
     backdrop-filter: blur(var(--blur-amount));
 }
 
-.bsky-widget iframe {
+.bsky-widget bsky-embed {
+    display: block;
     width: 100%;
     height: 100%;
     border: none;


### PR DESCRIPTION
## Summary
- embed Bluesky timeline with bsky-embed component
- drop custom Bluesky fetch logic and iframe styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae1de4214832eb6f2fcad2ab14ce7