### PR TITLE
feat: add interactive Bluesky widget

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,9 +38,12 @@
                     </div>
                 </button>
                 <div class="header-title">VIALTY</div>
+                <button class="bsky-toggle" id="bskyToggle" aria-label="Show Bluesky feed">
+                  <span class="bsky-icon" aria-hidden="true">🦋</span>
+                </button>
             </header>
 
-            <aside class="bsky-widget" id="bskyWidget">
+            <aside class="bsky-widget" id="bskyWidget" aria-hidden="true">
                 <script async src="https://cdn.jsdelivr.net/npm/bsky-embed/dist/bsky-embed.es.js" type="module"></script>
                 <bsky-embed username="vialty.site" limit="1"></bsky-embed>
             </aside>

--- a/public/script.js
+++ b/public/script.js
@@ -10,6 +10,8 @@ const cancelPost = document.getElementById('cancelPost');
 const postForm = document.getElementById('postForm');
 const blogGrid = document.getElementById('blogGrid');
 const projectsGrid = document.getElementById('projectsGrid');
+const bskyWidget = document.getElementById('bskyWidget');
+const bskyToggle = document.getElementById('bskyToggle');
 
 // State
 let blogPosts = [];
@@ -265,7 +267,46 @@ function setupEventListeners() {
     if (postForm) {
         postForm.addEventListener('submit', handlePostSubmit);
     }
-    
+
+  // Bluesky widget
+  if (bskyToggle && bskyWidget) {
+    const isTouch = window.matchMedia('(hover: none)').matches;
+    const showWidget = () => {
+      bskyWidget.classList.add('show');
+      bskyWidget.setAttribute('aria-hidden', 'false');
+    };
+    const hideWidget = () => {
+      bskyWidget.classList.remove('show');
+      bskyWidget.setAttribute('aria-hidden', 'true');
+    };
+
+    if (isTouch) {
+      bskyToggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        bskyWidget.classList.toggle('show');
+        const isShown = bskyWidget.classList.contains('show');
+        bskyWidget.setAttribute('aria-hidden', String(!isShown));
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!bskyWidget.contains(e.target) && e.target !== bskyToggle) {
+          hideWidget();
+        }
+      });
+    } else {
+      bskyToggle.addEventListener('mouseenter', showWidget);
+      bskyToggle.addEventListener('mouseleave', () => {
+        setTimeout(() => {
+          if (!bskyWidget.matches(':hover')) {
+            hideWidget();
+          }
+        }, 100);
+      });
+      bskyWidget.addEventListener('mouseenter', showWidget);
+      bskyWidget.addEventListener('mouseleave', hideWidget);
+    }
+  }
+
     // ESC key to close modals
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {

--- a/public/style.css
+++ b/public/style.css
@@ -129,6 +129,33 @@
     transition: all 0.3s ease;
 }
 
+/* Bluesky toggle */
+.bsky-toggle {
+  width: 50px;
+  height: 50px;
+  margin-left: auto;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.bsky-toggle:hover {
+  background: var(--hover-bg);
+  border-color: var(--primary-glow);
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
+}
+
+.bsky-icon {
+  font-size: 24px;
+}
+
 /* Navigation menu */
 .nav-menu {
     position: fixed;
@@ -941,23 +968,34 @@
 
 /* Bluesky widget */
 .bsky-widget {
-    position: fixed;
-    top: 100px;
-    right: 20px;
-    width: 320px;
-    height: 420px;
-    background: var(--glass-bg);
-    border: 1px solid var(--glass-border);
-    border-radius: 16px;
-    overflow: hidden;
-    backdrop-filter: blur(var(--blur-amount));
+  position: fixed;
+  top: 90px;
+  right: 30px;
+  width: 320px;
+  height: 420px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  overflow: hidden;
+  backdrop-filter: blur(var(--blur-amount));
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 1100;
+}
+
+.bsky-widget.show {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 
 .bsky-widget bsky-embed {
-    display: block;
-    width: 100%;
-    height: 100%;
-    border: none;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: none;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- add a header toggle to reveal Bluesky feed on demand
- animate Bluesky widget and improve styling
- handle hover and touch to open or dismiss the feed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aae656ec30832ea3cc8f0348e9ead7