### PR TITLE
Improve Bluesky widget layout and mobile behaviour

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -270,7 +270,10 @@ function setupEventListeners() {
 
   // Bluesky widget
   if (bskyToggle && bskyWidget) {
-    const isTouch = window.matchMedia('(hover: none)').matches;
+    const isTouch =
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints > 0 ||
+      window.matchMedia('(hover: none)').matches;
     const showWidget = () => {
       bskyWidget.classList.add('show');
       bskyWidget.setAttribute('aria-hidden', 'false');
@@ -561,15 +564,15 @@ style.textContent = `
         }
     }
     
-    @keyframes slideOutFade {
-        from {
-            opacity: 1;
-            transform: translateX(0);
-        }
-        to {
-            opacity: 0;
-            transform: translateX(100px);
-        }
+@keyframes slideOutFade {
+    from {
+        opacity: 1;
+        transform: translateX(0);
     }
+    to {
+        opacity: 0;
+        transform: translateX(100px);
+    }
+}
 `;
 document.head.appendChild(style);

--- a/public/style.css
+++ b/public/style.css
@@ -972,11 +972,11 @@
   top: 90px;
   right: 30px;
   width: 320px;
-  height: 420px;
+  max-height: 90vh;
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
   border-radius: 16px;
-  overflow: hidden;
+  overflow-y: auto;
   backdrop-filter: blur(var(--blur-amount));
   opacity: 0;
   pointer-events: none;
@@ -994,7 +994,7 @@
 .bsky-widget bsky-embed {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
   border: none;
 }
 
@@ -1042,6 +1042,7 @@
     }
 
     .bsky-widget {
-        display: none;
+        right: 10px;
+        width: calc(100% - 20px);
     }
 }


### PR DESCRIPTION
## Summary
- Make Bluesky widget height adapt to its content
- Enable Bluesky widget on small screens with improved touch detection

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae91724a0832eacafef34e958029a