### PR TITLE
Optimize blob image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Vialty Blog
 
 Don't you DARE using anything from this repository.
+
+## Development Notes
+
+- Image admin API caches listings in Redis to limit Blob `list` calls.
+- Renames reuse Blob's `copy` when possible to avoid extra uploads.

--- a/api/_redis.js
+++ b/api/_redis.js
@@ -8,8 +8,11 @@ const memoryClient = {
   async get(key) {
     return memoryStore[key] ?? null;
   },
-  async set(key, value) {
+  async set(key, value, _opts) {
     memoryStore[key] = value;
+  },
+  async del(key) {
+    delete memoryStore[key];
   },
   async quit() {
     // No-op for memory client

--- a/api/package.json
+++ b/api/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "sqlite3": "^5.1.6",
-    "@vercel/blob": "^0.8.2",
+    "@vercel/blob": "^1.0.2",
     "sharp": "^0.33.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- cache image list responses in Redis to minimize blob list calls
- rename images via blob copy when extensions match, falling back to re-upload
- expose `del` in in-memory Redis client and upgrade `@vercel/blob` for copy support

## Testing
- `npm install` *(fails: 403 Forbidden @vercel/blob)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aafaaea054832e99112bc8bf8492e4