### PR TITLE
Prevent admin buttons from submitting forms

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -32,7 +32,7 @@
 
         <!-- Admin Dashboard -->
         <div id="adminDashboard" style="display: none;">
-            <button id="sidebarToggle" class="sidebar-toggle" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">
+            <button id="sidebarToggle" class="sidebar-toggle" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false" type="button">
                 <span class="bar"></span>
                 <span class="bar"></span>
                 <span class="bar"></span>
@@ -93,7 +93,7 @@
                 <section id="postsSection" class="content-section active">
                     <div class="section-header">
                         <h2>Manage Blog Posts</h2>
-                        <button class="btn-primary" id="newPostBtn">
+                        <button class="btn-primary" id="newPostBtn" type="button">
                             <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
                                 <path d="M10 4v12m-6-6h12" stroke="currentColor" stroke-width="2"/>
                             </svg>
@@ -138,7 +138,7 @@
                 <section id="projectsSection" class="content-section">
                     <div class="section-header">
                         <h2>Manage Projects</h2>
-                        <button class="btn-primary" id="newProjectBtn">
+                        <button class="btn-primary" id="newProjectBtn" type="button">
                             <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
                                 <path d="M10 4v12m-6-6h12" stroke="currentColor" stroke-width="2"/>
                             </svg>
@@ -168,7 +168,7 @@
                 <section id="imagesSection" class="content-section">
                     <div class="section-header">
                         <h2>Manage Images</h2>
-                        <button class="btn-primary" id="newImageBtn">
+                        <button class="btn-primary" id="newImageBtn" type="button">
                             <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
                                 <path d="M10 4v12m-6-6h12" stroke="currentColor" stroke-width="2"/>
                             </svg>
@@ -196,7 +196,7 @@
                 <section id="ipsSection" class="content-section">
                     <div class="section-header">
                         <h2>Manage Admin IPs</h2>
-                        <button class="btn-primary" id="addIPBtn">
+                        <button class="btn-primary" id="addIPBtn" type="button">
                             <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
                                 <path d="M10 4v12m-6-6h12" stroke="currentColor" stroke-width="2"/>
                             </svg>
@@ -229,7 +229,7 @@
             <div class="modal-content large">
                 <div class="modal-header">
                     <h3 id="modalTitle">Create New Post</h3>
-                    <button class="modal-close" id="closePostModal">
+                    <button class="modal-close" id="closePostModal" type="button">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                             <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2"/>
                         </svg>
@@ -280,7 +280,7 @@
             <div class="modal-content large">
                 <div class="modal-header">
                     <h3 id="projectModalTitle">Create New Project</h3>
-                    <button class="modal-close" id="closeProjectModal">
+                    <button class="modal-close" id="closeProjectModal" type="button">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                             <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2"/>
                         </svg>
@@ -333,7 +333,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h3>Upload Image</h3>
-                    <button class="modal-close" id="closeImageModal">
+                    <button class="modal-close" id="closeImageModal" type="button">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                             <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2"/>
                         </svg>
@@ -361,7 +361,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h3>Rename Image</h3>
-                    <button class="modal-close" id="closeRenameModal">
+                    <button class="modal-close" id="closeRenameModal" type="button">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                             <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2"/>
                         </svg>
@@ -386,7 +386,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h3>Add Admin IP</h3>
-                    <button class="modal-close" id="closeIPModal">
+                    <button class="modal-close" id="closeIPModal" type="button">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                             <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2"/>
                         </svg>


### PR DESCRIPTION
## Summary
- ensure admin dashboard buttons use `type="button"` so clicking them doesn't submit the first form on the page
- fix modal close buttons to avoid default submissions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5bd7de18832ea748a7745489f1c6